### PR TITLE
Fix README link

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,7 @@ category:            Development
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Please see the README on Github at <https://github.com/commercialhaskell/stack/blob/master/subs/hi-file-parser/README.md>
+description:         Please see the README on Github at <https://github.com/commercialhaskell/hi-file-parser/blob/master/README.md>
 
 dependencies:
 - base >= 4.10 && < 5


### PR DESCRIPTION
Also I see links from https://hackage.haskell.org/package/hi-file-parser to Stack's GitHub pages and I wonder if those need to be updates as well