### PR TITLE
Fix #4 Allow dependency on mtl >= 2.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for hi-file-parser
 
+## Unreleased
+
+Allow dependency on `mtl` >= 2.3.
+
 ## 0.1.2.0
 
 Add support for GHC 8.10 and 9.0 [#2](https://github.com/commercialhaskell/hi-file-parser/pull/2)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2019-07-15
+resolver: lts-19.18

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 519764
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2019/7/15.yaml
-    sha256: 3f93a8081b0d3e6ee2b463886b1cc9f60403fae8a2eaeab4701b6e6150dfc98d
-  original: nightly-2019-07-15
+    sha256: 65b9809265860e085b4f61d4eb00d5d73e41190693620385a69cc9d9df7a901d
+    size: 619164
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/18.yaml
+  original: lts-19.18


### PR DESCRIPTION
From `mtl-2.3`, `Control.Monad.State` no longer re-exports `Control.Monad.when`.

Also avoids warning in respect of the `Data.Semigroup` import.

Also bumps `stack.yaml` to a recent version of GHC (as earlier version fails on Windows).

Tested by building with Stack with a dependency on `mtl-2.3`.