### PR TITLE
Drop support for GHC 9.12.1 alphas, now GHC 9.12.1 released

### DIFF
--- a/hi-file-parser.cabal
+++ b/hi-file-parser.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -39,16 +39,18 @@ extra-source-files:
     test-files/iface/x64/ghc9028/X.hi
     test-files/iface/x64/ghc9044/Main.hi
     test-files/iface/x64/ghc9044/X.hi
-    test-files/iface/x64/ghc9047/Main.hi
-    test-files/iface/x64/ghc9047/X.hi
-    test-files/iface/x64/ghc9066/Main.hi
-    test-files/iface/x64/ghc9066/X.hi
-    test-files/iface/x64/ghc9083/Main.hi
-    test-files/iface/x64/ghc9083/X.hi
-    test-files/iface/x64/ghc9101/Main.hi
-    test-files/iface/x64/ghc9101/X.hi
-    test-files/iface/x64/ghc9120/Main.hi
-    test-files/iface/x64/ghc9120/X.hi
+    test-files/iface/x64/ghc9048/Main.hi
+    test-files/iface/x64/ghc9048/X.hi
+    test-files/iface/x64/ghc9067/Main.hi
+    test-files/iface/x64/ghc9067/X.hi
+    test-files/iface/x64/ghc9084/Main.hi
+    test-files/iface/x64/ghc9084/X.hi
+    test-files/iface/x64/ghc9102/Main.hi
+    test-files/iface/x64/ghc9102/X.hi
+    test-files/iface/x64/ghc9122/Main.hi
+    test-files/iface/x64/ghc9122/X.hi
+    test-files/iface/x64/ghc9140/Main.hi
+    test-files/iface/x64/ghc9140/X.hi
 
 source-repository head
   type: git

--- a/package.yaml
+++ b/package.yaml
@@ -28,16 +28,18 @@ extra-source-files:
 - test-files/iface/x64/ghc9028/X.hi
 - test-files/iface/x64/ghc9044/Main.hi
 - test-files/iface/x64/ghc9044/X.hi
-- test-files/iface/x64/ghc9047/Main.hi
-- test-files/iface/x64/ghc9047/X.hi
-- test-files/iface/x64/ghc9066/Main.hi
-- test-files/iface/x64/ghc9066/X.hi
-- test-files/iface/x64/ghc9083/Main.hi
-- test-files/iface/x64/ghc9083/X.hi
-- test-files/iface/x64/ghc9101/Main.hi
-- test-files/iface/x64/ghc9101/X.hi
-- test-files/iface/x64/ghc9120/Main.hi
-- test-files/iface/x64/ghc9120/X.hi
+- test-files/iface/x64/ghc9048/Main.hi
+- test-files/iface/x64/ghc9048/X.hi
+- test-files/iface/x64/ghc9067/Main.hi
+- test-files/iface/x64/ghc9067/X.hi
+- test-files/iface/x64/ghc9084/Main.hi
+- test-files/iface/x64/ghc9084/X.hi
+- test-files/iface/x64/ghc9102/Main.hi
+- test-files/iface/x64/ghc9102/X.hi
+- test-files/iface/x64/ghc9122/Main.hi
+- test-files/iface/x64/ghc9122/X.hi
+- test-files/iface/x64/ghc9140/Main.hi
+- test-files/iface/x64/ghc9140/X.hi
 
 # Metadata used when publishing your package
 synopsis: Parser for GHC's hi files


### PR DESCRIPTION
Consistent approach with GHC 9.12 to versions of GHC before GHC 9.12.